### PR TITLE
test: add mock clock to test created at timestamp for new identities

### DIFF
--- a/src/main/java/com/github/ec25779/digitalid/central/CoreIdentityManager.java
+++ b/src/main/java/com/github/ec25779/digitalid/central/CoreIdentityManager.java
@@ -7,6 +7,7 @@ import com.github.ec25779.digitalid.model.IdentityNotFoundException;
 import com.github.ec25779.digitalid.repository.DigitalIdRepository;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,14 +15,20 @@ import java.util.UUID;
 public class CoreIdentityManager implements DigitalIdentityManager {
 
     private final DigitalIdRepository repository;
+    private final Clock clock;
+
+    public CoreIdentityManager(@NotNull DigitalIdRepository repository, @NotNull Clock clock) {
+        this.repository = repository;
+        this.clock = clock;
+    }
 
     public CoreIdentityManager(@NotNull DigitalIdRepository repository) {
-        this.repository = repository;
+        this(repository, Clock.systemUTC());
     }
 
     @Override
     public @NotNull DigitalId createIdentity(@NotNull OrganizationId caller, @NotNull CreateIdentityCommand command) {
-        DigitalId digitalId = new DigitalId(UUID.randomUUID(), Instant.now(), command.dateOfBirth(),
+        DigitalId digitalId = new DigitalId(UUID.randomUUID(), clock.instant(), command.dateOfBirth(),
             command.placeOfBirth(), command.biologicalSex(), command.fullName(), command.address(), DigitalIdStatus.ACTIVE);
         repository.save(digitalId);
 

--- a/src/test/java/com/github/ec25779/digitalid/central/DigitalIdentityManagerTest.java
+++ b/src/test/java/com/github/ec25779/digitalid/central/DigitalIdentityManagerTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DigitalIdentityManagerTest {
 
     private static final OrganizationId ORGANIZATION_ID = new OrganizationId("central-authority");
+    private static final Instant FIXED_NOW = Instant.parse("2026-04-23T00:00:00Z");
     private static final LocalDate TEST_DATE_OF_BIRTH = LocalDate.of(2000, 1, 1);
 
     private DigitalIdRepository repository;
@@ -33,8 +37,9 @@ public class DigitalIdentityManagerTest {
             .grant(ORGANIZATION_ID, Permission.CREATE_IDENTITY, Permission.UPDATE_IDENTITY)
             .build();
 
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
         identityManager = new AuthorizingIdentityManager(
-            new CoreIdentityManager(repository), permissionRegistry
+            new CoreIdentityManager(repository, clock), permissionRegistry
         );
     }
 
@@ -47,6 +52,7 @@ public class DigitalIdentityManagerTest {
         Optional<DigitalId> digitalId = repository.find(result.getId());
         assertTrue(digitalId.isPresent());
         assertEquals(digitalId.get(), result);
+        assertEquals(FIXED_NOW, result.getCreatedAt());
     }
 
     @Test


### PR DESCRIPTION
implements #10 